### PR TITLE
Ensure list of plugins does not have any duplicates

### DIFF
--- a/lib/Pluggable.pm6
+++ b/lib/Pluggable.pm6
@@ -20,7 +20,7 @@ role Pluggable {
         #CATCH { .say; }
       }
     };
-    return @list;
+    return @list.unique.Array;
   }
 
   method !search(Str $dir, Int $recursion = 10, :$baseclass, :$base, :$pattern){ #default to 10 iterations deep


### PR DESCRIPTION
#### Issue

If the directory with plugins is included more than once (e.g. `perl6 -Ilib -e '... use lib "lib"...'), the`$.plugins` method returns duplicates.
#### Solution

The original cause is Rakudo stuffing duplicates into `@*INC`, however, I can think of a possible case where a plugin could be installled in a "system" location as well as have a copy in user's `-Ilib`. Thus, instead of calling `.unique` on input, the `@*.INC`, I chose to `.unique` the output. The `.Array` bit is there to ensure we're still returning an `Array` instead of a `List` as the code without this fix does.
