### PR TITLE
Tests for (possibly) missing dir

### DIFF
--- a/lib/Pluggable.pm6
+++ b/lib/Pluggable.pm6
@@ -118,7 +118,8 @@ my sub find-modules($base, $namespace, $name-matcher) {
 
   for $*REPO.repo-chain -> $r {
     given $r.WHAT {
-      when CompUnit::Repository::FileSystem {
+        when CompUnit::Repository::FileSystem {
+            say $r.loaded;
         my @files = find(dir => $r.prefix, name => /\.pm6?$/);
         @files = map(-> $s { $s.substr($r.prefix.chars + 1) }, @files);
         @files = map(-> $s { $s.substr(0, $s.rindex('.')) }, @files);


### PR DESCRIPTION
Although that *shouldn't* happen (because, hey, it's a CUF, it should be *there*, right), it does happen in #11 and possibly #9. This might be a CUF error, but then CUF is underdocumented, and we could simply be relying on a fragile (and assumed) interface. At any rate, this will fix that particular error in perl6/ecosystem-unbitrot#502 by avoiding non-existing directories.
Also my emacs has re-indented everything. If you don't like that, I can de-indent. As a matter of fact, it's a single line (122), so it's probably OK if you close this PR and just add it yourself. 