### PR TITLE
Move tests depending on manual preparation to `xt/`

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,6 @@
         "Test::META"
     ],
     "test-depends" : [
-        "SVG::Plot::Pie",
         "File::Find"
     ],
     "provides" : {

--- a/xt/01-installation.t
+++ b/xt/01-installation.t
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl6
 
-use Pluggable; 
+use Pluggable;
 use Test;
 
 plan 1;


### PR DESCRIPTION
The test `02-installation.t` depends on having the module `SVG::Plot`
installed. That module was listed in `META6.json` `test-depends`, but this
did not help, as the module won't be installed until after installation.
So to sucessfully run the test one needs to manually install `SVG::Plot`
beforehand. So this test is no good fit for being run during automated
testing during installation.

Fixes #14 